### PR TITLE
Add REST endpoint and React portfolio component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# sebastienj
-template
+# Portfolio React pour Real Media Library
+
+Ce dépôt fournit un exemple minimaliste de portfolio d'artiste basé sur WordPress, React et le plugin **Real Media Library**. Il comprend :
+
+- `php/portfolio-rest.php` : un fichier PHP ajoutant une route REST `/wp-json/portfolio/v1/tree` qui expose l'arborescence des dossiers et images gérées par Real Media Library.
+- `src/PortfolioExplorer.jsx` : le composant React principal utilisant MUI pour naviguer dans les dossiers et afficher les images sans rechargement de page.
+- `styles/portfolio.css` : feuille de style légère pour un rendu épuré.
+
+## Mise en place
+
+1. **Activer la route REST**  
+   Copiez le fichier `php/portfolio-rest.php` dans un nouveau dossier sous `wp-content/plugins/` (par ex. `portfolio-rest/`) puis activez le plugin depuis l'administration WordPress.
+
+2. **Préparer le code React**  
+   Le composant React nécessite un bundler (par ex. `@wordpress/scripts`) et les dépendances MUI :
+   ```bash
+   npm install @wordpress/scripts react react-dom @mui/material @emotion/react @emotion/styled
+   ```
+   Placez `src/PortfolioExplorer.jsx` dans votre projet et compilez-le vers un fichier JavaScript chargé sur le site. Un exemple simple de bloc Gutenberg :
+   ```javascript
+   import { registerBlockType } from '@wordpress/blocks';
+   import PortfolioExplorer from './PortfolioExplorer';
+   import './portfolio.css';
+
+   registerBlockType('portfolio/explorer', {
+     edit: () => <PortfolioExplorer />, // rendu uniquement en mode édition
+     save: () => null,                   // pas de contenu statique
+   });
+   ```
+
+3. **Inclure le style**  
+   Copiez `styles/portfolio.css` aux côtés du script compilé et chargez-la avec `wp_enqueue_style`.
+
+4. **Utilisation**  
+   Dans l'éditeur Gutenberg, insérez le bloc `Portfolio Explorer`. La navigation dans les dossiers est instantanée et les images se chargent sous forme de grille responsive.
+
+## Route REST
+Une fois le plugin activé, la route suivante renvoie l'arborescence complète :
+```
+GET /wp-json/portfolio/v1/tree
+```
+La réponse est un tableau de dossiers, chacun contenant ses sous-dossiers (`children`) et ses images (`images` avec `title`, `url` et `thumb`).
+
+## Personnalisation
+- Le composant React gère un nombre illimité de niveaux de dossiers.
+- Ajoutez votre propre modal pour l'affichage plein écran des images si souhaité.
+- Le CSS fourni est volontairement minimal ; adaptez-le selon votre charte graphique.
+
+## Développement
+- PHP : vérifiez la syntaxe avec `php -l php/portfolio-rest.php`.
+- JS : utilisez vos outils habituels (`npm test`, `eslint`, etc.) pour valider le code.
+
+---
+Ce projet est un point de départ pour créer une page de portfolio moderne et fluide dans WordPress.

--- a/php/portfolio-rest.php
+++ b/php/portfolio-rest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Plugin Name: Portfolio RML REST
+ * Description: Expose Real Media Library tree via REST API.
+ */
+
+// Register custom REST route
+function portfolio_rml_register_rest() {
+    register_rest_route('portfolio/v1', '/tree', array(
+        'methods'  => 'GET',
+        'callback' => 'portfolio_rml_get_tree',
+        'permission_callback' => '__return_true',
+    ));
+}
+add_action('rest_api_init', 'portfolio_rml_register_rest');
+
+// Build folder tree recursively using Real Media Library taxonomy.
+function portfolio_rml_build_tree($parent_id = 0) {
+    $terms = get_terms(array(
+        'taxonomy'   => 'rml_folder',
+        'hide_empty' => false,
+        'parent'     => $parent_id,
+        'orderby'    => 'name',
+        'order'      => 'ASC',
+    ));
+
+    $tree = array();
+
+    foreach ($terms as $term) {
+        // Get attachments for this folder
+        $attachments = get_posts(array(
+            'post_type'      => 'attachment',
+            'post_status'    => 'inherit',
+            'numberposts'    => -1,
+            'tax_query'      => array(
+                array(
+                    'taxonomy' => 'rml_folder',
+                    'field'    => 'term_id',
+                    'terms'    => $term->term_id,
+                )
+            ),
+        ));
+
+        $images = array();
+        foreach ($attachments as $att) {
+            $images[] = array(
+                'id'    => $att->ID,
+                'title' => get_the_title($att->ID),
+                'url'   => wp_get_attachment_url($att->ID),
+                'thumb' => wp_get_attachment_image_url($att->ID, 'medium'),
+            );
+        }
+
+        $tree[] = array(
+            'id'       => $term->term_id,
+            'name'     => $term->name,
+            'children' => portfolio_rml_build_tree($term->term_id),
+            'images'   => $images,
+        );
+    }
+
+    return $tree;
+}
+
+function portfolio_rml_get_tree($request) {
+    $tree = portfolio_rml_build_tree();
+    return rest_ensure_response($tree);
+}

--- a/src/PortfolioExplorer.jsx
+++ b/src/PortfolioExplorer.jsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  CircularProgress,
+  ImageList,
+  ImageListItem,
+  List,
+  ListItemButton,
+  ListItemText,
+  Breadcrumbs,
+  Link
+} from '@mui/material';
+
+const FolderTree = ({ nodes, onSelect }) => (
+  <List className="portfolio-tree">
+    {nodes.map(node => (
+      <ListItemButton key={node.id} onClick={() => onSelect(node)}>
+        <ListItemText primary={node.name} />
+      </ListItemButton>
+    ))}
+  </List>
+);
+
+const PortfolioExplorer = () => {
+  const [tree, setTree] = useState([]);
+  const [current, setCurrent] = useState(null);
+  const [path, setPath] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/wp-json/portfolio/v1/tree')
+      .then(res => res.json())
+      .then(data => {
+        setTree(data);
+        setCurrent({ name: 'Racine', children: data, images: [] });
+        setLoading(false);
+      });
+  }, []);
+
+  const openFolder = folder => {
+    setPath([...path, folder]);
+    setCurrent(folder);
+  };
+
+  const goTo = index => {
+    const newPath = path.slice(0, index);
+    const folder = index === 0 ? { name: 'Racine', children: tree, images: [] } : path[index - 1];
+    setPath(newPath);
+    setCurrent(folder);
+  };
+
+  if (loading) {
+    return (
+      <Box className="portfolio-loader">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="portfolio-app">
+      <Breadcrumbs aria-label="breadcrumb" className="portfolio-breadcrumbs">
+        <Link underline="hover" key="root" onClick={() => { setPath([]); setCurrent({ name: 'Racine', children: tree, images: [] }); }}>Racine</Link>
+        {path.map((p, i) => (
+          <Link underline="hover" key={p.id} onClick={() => goTo(i + 1)}>{p.name}</Link>
+        ))}
+      </Breadcrumbs>
+      <Box className="portfolio-content">
+        {current.children && current.children.length > 0 && (
+          <FolderTree nodes={current.children} onSelect={openFolder} />
+        )}
+        {current.images && current.images.length > 0 && (
+          <ImageList variant="masonry" cols={3} gap={8} className="portfolio-grid">
+            {current.images.map(img => (
+              <ImageListItem key={img.id}>
+                <img src={img.thumb || img.url} alt={img.title} loading="lazy" />
+              </ImageListItem>
+            ))}
+          </ImageList>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default PortfolioExplorer;

--- a/styles/portfolio.css
+++ b/styles/portfolio.css
@@ -1,0 +1,36 @@
+.portfolio-app {
+  padding: 1rem;
+  font-family: 'Helvetica Neue', sans-serif;
+  color: #222;
+  background: #fafafa;
+}
+
+.portfolio-tree .MuiListItemButton-root {
+  padding-left: 0;
+}
+
+.portfolio-breadcrumbs {
+  margin-bottom: 1rem;
+}
+
+.portfolio-grid img {
+  width: 100%;
+  border-radius: 4px;
+  transition: transform 0.2s ease;
+}
+
+.portfolio-grid img:hover {
+  transform: scale(1.02);
+}
+
+.portfolio-loader {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+@media (max-width: 600px) {
+  .portfolio-grid {
+    column-count: 2 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add PHP REST endpoint exposing Real Media Library folders and images
- create React portfolio explorer component with Material UI and loader
- include minimal CSS and documentation for Gutenberg integration

## Testing
- `php -l php/portfolio-rest.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f2fb459e883228f8d4708a13a7a4d